### PR TITLE
Broadcast in quantile and cdf

### DIFF
--- a/crick/tdigest.pyx
+++ b/crick/tdigest.pyx
@@ -110,12 +110,15 @@ cdef class TDigest:
         ----------
         x : array_like or float
         """
-        x = np.array([x]) if np.isscalar(x) else np.asarray(x)
+        x = np.asarray(x)
         if not np.can_cast(x, 'f8', casting='safe'):
             raise TypeError("x must be numeric")
         if not np.isfinite(x).all():
             raise ValueError("x must be finite")
-        return <np.ndarray>tdigest_cdf_ndarray(self.tdigest, <np.PyArrayObject*>x)
+        out = <np.ndarray>tdigest_cdf_ndarray(self.tdigest, <np.PyArrayObject*>x)
+        if out.ndim == 0:
+            return np.float64(out)
+        return out
 
     def quantile(self, q):
         """quantile(self, q)
@@ -128,12 +131,15 @@ cdef class TDigest:
         q : array_like or float
             A number between 0 and 1 inclusive.
         """
-        q = np.array([q]) if np.isscalar(q) else np.asarray(q)
+        q = np.asarray(q)
         if not np.can_cast(q, 'f8', casting='safe'):
             raise TypeError("q must be numeric")
         if not np.isfinite(q).all():
             raise ValueError("q must be finite")
-        return <np.ndarray>tdigest_quantile_ndarray(self.tdigest, <np.PyArrayObject*>q)
+        out = <np.ndarray>tdigest_quantile_ndarray(self.tdigest, <np.PyArrayObject*>q)
+        if out.ndim == 0:
+            return np.float64(out)
+        return out
 
     def centroids(self):
         """centroids(self)
@@ -201,14 +207,9 @@ cdef class TDigest:
         w : array_like, optional
             The weight (or weights) of the values to add. Default is 1.
         """
-        x = np.array([x]) if np.isscalar(x) else np.asarray(x)
-        if np.isscalar(w):
-            # Don't check w in the common case where w is 1
-            check_w = w != 1
-            w = np.array([w])
-        else:
-            check_w = True
-            w = np.asarray(w)
+        x = np.asarray(x)
+        check_w = not (np.isscalar(w) and w == 1)
+        w = np.asarray(w)
 
         if not np.can_cast(x, 'f8', casting='safe'):
             raise TypeError("x must be numeric")

--- a/crick/tdigest_stubs.c
+++ b/crick/tdigest_stubs.c
@@ -364,7 +364,7 @@ static PyArrayObject *tdigest_cdf_ndarray(tdigest_t *T, PyArrayObject *x) {
 
     op[0] = x;
     op[1] = NULL;
-    flags = NPY_ITER_EXTERNAL_LOOP | NPY_ITER_BUFFERED;
+    flags = NPY_ITER_EXTERNAL_LOOP | NPY_ITER_BUFFERED | NPY_ITER_ZEROSIZE_OK;
     op_flags[0] = NPY_ITER_READONLY | NPY_ITER_ALIGNED;
     op_flags[1] = NPY_ITER_WRITEONLY | NPY_ITER_ALLOCATE | NPY_ITER_ALIGNED;
 
@@ -455,7 +455,7 @@ static PyArrayObject *tdigest_quantile_ndarray(tdigest_t *T, PyArrayObject *q) {
 
     op[0] = q;
     op[1] = NULL;
-    flags = NPY_ITER_EXTERNAL_LOOP | NPY_ITER_BUFFERED;
+    flags = NPY_ITER_EXTERNAL_LOOP | NPY_ITER_BUFFERED | NPY_ITER_ZEROSIZE_OK;
     op_flags[0] = NPY_ITER_READONLY | NPY_ITER_ALIGNED;
     op_flags[1] = NPY_ITER_WRITEONLY | NPY_ITER_ALLOCATE | NPY_ITER_ALIGNED;
 

--- a/crick/tests/test_tdigest.py
+++ b/crick/tests/test_tdigest.py
@@ -75,13 +75,13 @@ def test_distributions(data):
 
     # *Quantile
     q = np.array([0.001, 0.01, 0.1, 0.3, 0.5, 0.7, 0.9, 0.99, 0.999])
-    est = np.array([t.quantile(i) for i in q])
+    est = t.quantile(q)
     q_est = quantiles_to_q(data, est)
     np.testing.assert_allclose(q, q_est, atol=0.012, rtol=0)
 
     # *CDF
     x = q_to_x(data, q)
-    q_est = np.array([t.cdf(i) for i in x])
+    q_est = t.cdf(x)
     np.testing.assert_allclose(q, q_est, atol=0.005)
 
 
@@ -171,7 +171,7 @@ def test_small_w():
     assert len(t.centroids()) == 0
 
 
-def test_non_numeric_errors():
+def test_update_non_numeric_errors():
     data = np.array(['foo', 'bar', 'baz'])
     t = TDigest()
 
@@ -186,6 +186,28 @@ def test_non_numeric_errors():
 
     with pytest.raises(TypeError):
         t.add(1, 'foo')
+
+
+def test_quantile_non_numeric():
+    t = TDigest()
+    t.update(np.arange(5))
+
+    with pytest.raises(TypeError):
+        t.quantile('foo')
+
+    with pytest.raises(TypeError):
+        t.update(['foo'])
+
+
+def test_cdf_non_numeric():
+    t = TDigest()
+    t.update(np.arange(5))
+
+    with pytest.raises(TypeError):
+        t.cdf('foo')
+
+    with pytest.raises(TypeError):
+        t.cdf(['foo'])
 
 
 def test_weights():
@@ -239,13 +261,13 @@ def test_merge():
 
     # *Quantile
     q = np.array([0.001, 0.01, 0.1, 0.3, 0.5, 0.7, 0.9, 0.99, 0.999])
-    est = np.array([t.quantile(i) for i in q])
+    est = t.quantile(q)
     q_est = quantiles_to_q(data, est)
     np.testing.assert_allclose(q, q_est, atol=0.012, rtol=0)
 
     # *CDF
     x = q_to_x(data, q)
-    q_est = np.array([t.cdf(i) for i in x])
+    q_est = t.cdf(x)
     np.testing.assert_allclose(q, q_est, atol=0.005)
 
     with pytest.raises(TypeError):

--- a/crick/tests/test_tdigest.py
+++ b/crick/tests/test_tdigest.py
@@ -188,7 +188,7 @@ def test_update_non_numeric_errors():
         t.add(1, 'foo')
 
 
-def test_quantile_non_numeric():
+def test_quantile_and_cdf_non_numeric():
     t = TDigest()
     t.update(np.arange(5))
 
@@ -198,16 +198,36 @@ def test_quantile_non_numeric():
     with pytest.raises(TypeError):
         t.update(['foo'])
 
-
-def test_cdf_non_numeric():
-    t = TDigest()
-    t.update(np.arange(5))
-
     with pytest.raises(TypeError):
         t.cdf('foo')
 
     with pytest.raises(TypeError):
         t.cdf(['foo'])
+
+
+def test_quantile_and_cdf_shape():
+    t = TDigest()
+    t.update(np.arange(5))
+
+    assert isinstance(t.quantile(0.5), np.float64)
+    assert isinstance(t.cdf(2), np.float64)
+
+    res = t.quantile(())
+    assert res.shape == (0,)
+    res = t.cdf(())
+    assert res.shape == (0,)
+
+    q = np.array([0.5, 0.9])
+    res = t.quantile(q)
+    assert res.shape == (2,)
+    res = t.cdf(q)
+    assert res.shape == (2,)
+
+    q = np.array([[0.5, 0.9], [0, 1]])
+    res = t.quantile(q)
+    assert res.shape == (2, 2)
+    res = t.cdf(q)
+    assert res.shape == (2, 2)
 
 
 def test_weights():


### PR DESCRIPTION
Quantile and cdf now support numpy style broadcasting, using the
iterator api. This allows quantiles and cdf to be computed much more
efficiently by sharing intermediate computations between queries.