### PR TITLE
Add a `histogram` method

### DIFF
--- a/crick/tdigest_stubs.c
+++ b/crick/tdigest_stubs.c
@@ -303,6 +303,7 @@ static void tdigest_query_prep(tdigest_t *T) {
         T->merge_centroids[i - 1].weight = (a.mean + (b.mean - a.mean) *
                                             a.weight / (a.weight + b.weight));
     }
+    T->merge_centroids[T->last].weight = T->max;
 }
 
 

--- a/crick/tests/test_tdigest.py
+++ b/crick/tests/test_tdigest.py
@@ -230,6 +230,19 @@ def test_quantile_and_cdf_shape():
     assert res.shape == (2, 2)
 
 
+def test_quantile_and_cdf_monotonic_increasing():
+    # Check that quantile and cdf are monotonically increasing
+    # if given increasing inputs
+    t = TDigest()
+    t.update(np.random.normal(size=10000))
+    q = np.linspace(0, 1, 100, endpoint=True)
+    res = t.quantile(q)
+    assert (np.diff(res) > 0).all()
+    x = np.linspace(t.min(), t.max(), 100, endpoint=True)
+    res = t.cdf(x)
+    assert (np.diff(x) > 0).all()
+
+
 def test_weights():
     t = TDigest()
     t.add(1, 10)


### PR DESCRIPTION
Add a histogram function for generating a histogram from a t-digest.
Mirrors the relevant parts of the numpy `histogram` function.