### PR TITLE
Drop python 3.3, add 3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,11 +3,11 @@ sudo: false
 
 env:
   matrix:
-    - PYTHON=2.7 NUMPY=1.10.4
-    - PYTHON=2.7 NUMPY=1.11.0
-    - PYTHON=3.3 NUMPY=1.9.2
-    - PYTHON=3.4 NUMPY=1.10.4
-    - PYTHON=3.5 NUMPY=1.11.0
+    - PYTHON=2.7 NUMPY=1.10
+    - PYTHON=2.7 NUMPY=1.11
+    - PYTHON=3.4 NUMPY=1.9
+    - PYTHON=3.5 NUMPY=1.10
+    - PYTHON=3.6 NUMPY=1.11
 
 install:
     # Install conda

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,13 +8,13 @@ environment:
         CMD_IN_ENV: "cmd /E:ON /V:ON /C .\\tools\\run_with_env.cmd"
 
     matrix:
-        - PYTHON_VERSION: "3.5"
+        - PYTHON_VERSION: "3.6"
           PYTHON_ARCH: "64"
           NUMPY: "1.11"
 
         - PYTHON_VERSION: "2.7"
           PYTHON_ARCH: "64"
-          NUMPY: "1.10.4"
+          NUMPY: "1.10"
 
 platform:
     - x64


### PR DESCRIPTION
Update travis and appveyor to use python 3.6, drop testing for 3.3.