### PR TITLE
Bump numpy version on CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,11 +3,10 @@ sudo: false
 
 env:
   matrix:
-    - PYTHON=2.7 NUMPY=1.10
     - PYTHON=2.7 NUMPY=1.11
-    - PYTHON=3.4 NUMPY=1.9
-    - PYTHON=3.5 NUMPY=1.10
-    - PYTHON=3.6 NUMPY=1.11
+    - PYTHON=2.7 NUMPY=1.14
+    - PYTHON=3.5 NUMPY=1.11
+    - PYTHON=3.6 NUMPY=1.14
 
 install:
     # Install conda

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,11 +10,11 @@ environment:
     matrix:
         - PYTHON_VERSION: "3.6"
           PYTHON_ARCH: "64"
-          NUMPY: "1.11"
+          NUMPY: "1.14"
 
         - PYTHON_VERSION: "2.7"
           PYTHON_ARCH: "64"
-          NUMPY: "1.10"
+          NUMPY: "1.11"
 
 platform:
     - x64

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,7 +10,7 @@ environment:
     matrix:
         - PYTHON_VERSION: "3.6"
           PYTHON_ARCH: "64"
-          NUMPY: "1.14"
+          NUMPY: "1.13"
 
         - PYTHON_VERSION: "2.7"
           PYTHON_ARCH: "64"

--- a/crick/tdigest_stubs.c
+++ b/crick/tdigest_stubs.c
@@ -5,7 +5,6 @@
 #include <stdlib.h>
 #include <float.h>
 #include <assert.h>
-#include <signal.h>
 
 #include <Python.h>
 #include <numpy/arrayobject.h>


### PR DESCRIPTION
Bump to test on 1.11 and 1.14 (assuming intermediate versions will pass). Also removes extraneous include.