### PR TITLE
Update space_saving.pyx

### DIFF
--- a/crick/space_saving.pyx
+++ b/crick/space_saving.pyx
@@ -85,7 +85,7 @@ cdef np.dtype COUNTER_FLOAT64_DTYPE = np.dtype(
 
 cdef np.dtype COUNTER_OBJECT_DTYPE = np.dtype(
         {'names': ['item', 'count', 'error'],
-         'formats': [np.object, np.int64, np.int64],
+         'formats': [object, np.int64, np.int64],
          'offsets': [<size_t> &(<counter_object_t*> NULL).item,
                      <size_t> &(<counter_object_t*> NULL).count,
                      <size_t> &(<counter_object_t*> NULL).error


### PR DESCRIPTION
```
  /Users/taugspurger/Envs/dask-dev/lib/python3.7/site-packages/crick/__init__.py:4: DeprecationWarning: `np.object` is a deprecated alias for the builtin `object`. Use `object` by
itself, which is identical in behavior, to silence this warning. If you specifically wanted the numpy scalar type, use `np.object_` here.
    from .space_saving import SpaceSaving
```

`np.object` is a deprecated alias for `object` in NumPy 1.20

