### PR TITLE
Fix sequence point error

### DIFF
--- a/crick/stats_stubs.c
+++ b/crick/stats_stubs.c
@@ -129,7 +129,7 @@ CRICK_INLINE double stats_kurt(stats_t *T, int fisher, int bias) {
     n = T->count;
     m2 = T->m2 / T->count;
     m4 = T->m4 / T->count;
-    kurt = m2 ? kurt = m4 / (m2 * m2) : 0;
+    kurt = m2 ? m4 / (m2 * m2) : 0;
     if (!bias && n > 3 && m2 > 0)
         kurt = ((n*n - 1)*kurt - 9*n + 15)/((n - 2)*(n - 3));
     return fisher ? kurt - 3 : kurt;


### PR DESCRIPTION
Fixes this GCC warning:
```
  In file included from crick/stats.c:1265:
  crick/stats_stubs.c: In function ‘stats_kurt’:
  crick/stats_stubs.c:132:10: warning: operation on ‘kurt’ may be undefined [-Wsequence-point]
    132 |     kurt = m2 ? kurt = m4 / (m2 * m2) : 0;
        |     ~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```
