### PR TITLE
Fix reference counting issue (#65)

### DIFF
--- a/crick/space_saving_stubs.c.in
+++ b/crick/space_saving_stubs.c.in
@@ -97,10 +97,9 @@ fail:
 
 CRICK_INLINE void spsv_{{name}}_free(spsv_{{name}}_t *T) {
     {{if refcount}}
-    khiter_t iter;
-    for (iter = kh_begin(T->hashmap); iter != kh_end(T->hashmap); ++iter) {
-        if (kh_exist(T->hashmap, iter))
-            Py_DECREF(kh_key(T->hashmap, iter));
+    npy_intp i;
+    for (i = 0; i < T->size; ++i) {
+        Py_DECREF(T->list[i].counter.item);
     }
     {{endif}}
     kh_destroy({{name}}, T->hashmap);


### PR DESCRIPTION
Fixes https://github.com/dask/crick/issues/65.  I *think* what is going on is that a hash table merge can leave the same object in two hash tables, so when both hash tables are deleted, that object's reference count is decremented twice.  Since the reference count is incremented only when an object is added to `T->list`, I took the approach of decrementing the reference count based on the contents of `T->list`, instead of trying to figure out how to tweak reference counts during a merge.  In my tests with Fedora Rawhide, this lets the test suite pass without segfaulting.
